### PR TITLE
Split definition file

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,4 +8,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: stoplightio/spectral-action@v0.7.0
         with:
-          file_glob: 'definitions/v1.1/*.yaml'
+          file_glob: 'src/v1.1/*.{json,yaml,yml}'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+definitions/v1.1/.openapi-generator/*

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ default: lint
 
 .PHONY: lint
 lint:
-	docker run -it --rm -v $$PWD:$$PWD -w $$PWD stoplight/spectral:master lint -s path-not-include-query definitions/v1.1/apis.yaml
+	docker run -it --rm -v $$PWD:$$PWD -w $$PWD stoplight/spectral:master lint -s path-not-include-query definitions/v1.1/openapi.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,20 @@
-default: lint
+default: lint gen
+
+.PHONY: tools
+	npm install -g @apidevtools/swagger-cli
+
 
 .PHONY: lint
 lint:
-	docker run -it --rm -v $$PWD:$$PWD -w $$PWD stoplight/spectral:master lint -s path-not-include-query definitions/v1.1/openapi.yaml
+	docker run -it --rm -v $$PWD:$$PWD -w $$PWD stoplight/spectral:master lint -s path-not-include-query -s oas3-unused-components-schema src/v1.1/root.yaml
+
+.PHONY: lint_all
+lint_all:
+	docker run -it --rm -v $$PWD:$$PWD -w $$PWD stoplight/spectral:master lint -s path-not-include-query -s oas3-unused-components-schema {src,definitions}/v1.1/*.{json,yaml,yml}
+
+.PHONT: gen _gen
+gen: _gen lint_all
+
+_gen:
+	swagger-cli bundle src/v1.1/root.yaml -o definitions/v1.1/openapi.yaml --type yaml
+	swagger-cli bundle src/v1.1/root.yaml -o definitions/v1.1/openapi.json --type json

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 This project provides machine-readable schema definitions for SAKURA Cloud APIs.
 
 - API Documents(current: `v1.1`): https://developer.sakura.ad.jp/cloud/api/1.1/ 
-- Open API v3 Schemas: [definitions/v1.1/apis.yaml](definitions/v1.1/apis.yaml)
+- Open API v3 Schemas: 
+  - YAML: [definitions/v1.1/apis.yaml](definitions/v1.1/openapi.yaml)
+  - JSON: [definitions/v1.1/apis.yaml](definitions/v1.1/openapi.json)
 - Live Demo: [TODO]
 
 ## License

--- a/definitions/v1.1/.openapi-generator-ignore
+++ b/definitions/v1.1/.openapi-generator-ignore
@@ -1,0 +1,1 @@
+README.md

--- a/definitions/v1.1/README.md
+++ b/definitions/v1.1/README.md
@@ -1,0 +1,7 @@
+# OpenAPI definitions for SAKURA Cloud APIs
+
+This directory contains the built/combined definition files.
+**DO NOT EDIT** these files directly.
+
+- YAML: [openapi.yaml](./openapi.yaml)
+- JSON: [openapi.json](./openapi.json)

--- a/definitions/v1.1/openapi.json
+++ b/definitions/v1.1/openapi.json
@@ -1,0 +1,327 @@
+{
+  "openapi": "3.0.3",
+  "tags": [
+    {
+      "name": "icons",
+      "description": "Operations for Icon resource"
+    }
+  ],
+  "info": {
+    "title": "SAKURA Cloud APIs",
+    "version": "1.0.0",
+    "description": "This is a definitions for SAKURA Cloud APIs.",
+    "termsOfService": "https://www.sakura.ad.jp/agreement/",
+    "contact": {
+      "name": "Maintainers",
+      "url": "https://github.com/sacloud/schema"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/zone/{zone}/api/cloud/1.1",
+      "variables": {
+        "zone": {
+          "default": "is1a",
+          "enum": [
+            "is1a",
+            "is1b",
+            "tk1a",
+            "tk1b",
+            "tk1v"
+          ]
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/icon?{params}": {
+      "get": {
+        "summary": "List all Icons",
+        "description": "List all Icons",
+        "operationId": "listIcons",
+        "tags": [
+          "icons"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "required": true,
+            "name": "params",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IconFindParameter"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of icons",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Icon"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "default": {
+            "$ref": "#/components/responses/UnexpectedError"
+          }
+        }
+      }
+    },
+    "/icon": {
+      "post": {
+        "summary": "Create a icon",
+        "description": "Create a icon",
+        "operationId": "createIcons",
+        "tags": [
+          "icons"
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Icon"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "default": {
+            "$ref": "#/components/responses/UnexpectedError"
+          }
+        }
+      }
+    },
+    "/icon/{iconId}": {
+      "get": {
+        "summary": "Info for a specific Icon",
+        "description": "Info for a specific Icon",
+        "operationId": "showIconById",
+        "tags": [
+          "icons"
+        ],
+        "parameters": [
+          {
+            "name": "iconId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the icon to retrieve",
+            "schema": {
+              "$ref": "#/components/schemas/ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Icon"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "default": {
+            "$ref": "#/components/responses/UnexpectedError"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "basicAuth": []
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    },
+    "schemas": {
+      "ID": {
+        "oneOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "format": "int64"
+      },
+      "FindResultMeta": {
+        "type": "object",
+        "properties": {
+          "Count": {
+            "type": "integer"
+          },
+          "From": {
+            "type": "integer"
+          },
+          "Total": {
+            "type": "integer"
+          },
+          "is_ok": {
+            "type": "boolean"
+          }
+        }
+      },
+      "APIError": {
+        "type": "object",
+        "properties": {
+          "is_fatal": {
+            "type": "boolean"
+          },
+          "serial": {
+            "type": "string"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "error_msg": {
+            "type": "string"
+          }
+        }
+      },
+      "IconFindParameter": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "Filter": {
+            "$ref": "#/components/schemas/IconFindFilter"
+          }
+        }
+      },
+      "IconFindFilter": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "Scope": {
+            "type": "string",
+            "enum": [
+              "user",
+              "shared"
+            ]
+          },
+          "Name": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "Tags.Name": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Icon": {
+        "type": "object",
+        "properties": {
+          "Availability": {
+            "type": "string"
+          },
+          "CreatedAt": {
+            "type": "string"
+          },
+          "ID": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "Index": {
+            "type": "integer"
+          },
+          "ModifiedAt": {
+            "type": "string"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Scope": {
+            "type": "string"
+          },
+          "Tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "URL": {
+            "type": "string"
+          }
+        }
+      },
+      "Icons": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FindResultMeta"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Icons": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Icon"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "responses": {
+      "UnauthorizedError": {
+        "description": "Authentication information is missing or invalid",
+        "headers": {
+          "WWW_Authenticate": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/APIError"
+            }
+          }
+        }
+      },
+      "UnexpectedError": {
+        "description": "unexpected error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/APIError"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/definitions/v1.1/openapi.yaml
+++ b/definitions/v1.1/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.3"
+openapi: 3.0.3
 tags:
   - name: icons
     description: Operations for Icon resource
@@ -6,15 +6,15 @@ info:
   title: SAKURA Cloud APIs
   version: 1.0.0
   description: This is a definitions for SAKURA Cloud APIs.
-  termsOfService: https://www.sakura.ad.jp/agreement/
+  termsOfService: 'https://www.sakura.ad.jp/agreement/'
   contact:
     name: Maintainers
-    url: https://github.com/sacloud/schema
+    url: 'https://github.com/sacloud/schema'
   license:
     name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 servers:
-  - url: https://secure.sakura.ad.jp/cloud/zone/{zone}/api/cloud/1.1
+  - url: 'https://secure.sakura.ad.jp/cloud/zone/{zone}/api/cloud/1.1'
     variables:
       zone:
         default: is1a
@@ -25,7 +25,7 @@ servers:
           - tk1b
           - tk1v
 paths:
-  /icon?{params}:
+  '/icon?{params}':
     get:
       summary: List all Icons
       description: List all Icons
@@ -35,18 +35,18 @@ paths:
       parameters:
         - in: path
           required: true
-          name: "params"
+          name: params
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListIconParameter'
+                $ref: '#/components/schemas/IconFindParameter'
       responses:
         '200':
           description: An array of icons
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Icons"
+                $ref: '#/components/schemas/Icon'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         default:
@@ -64,12 +64,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Icon"
+                $ref: '#/components/schemas/Icon'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         default:
           $ref: '#/components/responses/UnexpectedError'
-  /icon/{iconId}:
+  '/icon/{iconId}':
     get:
       summary: Info for a specific Icon
       description: Info for a specific Icon
@@ -82,86 +82,31 @@ paths:
           required: true
           description: The id of the icon to retrieve
           schema:
-            $ref: "#/components/schemas/ID"
+            $ref: '#/components/schemas/ID'
       responses:
         '200':
           description: Expected response to a valid request
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Icon"
+                $ref: '#/components/schemas/Icon'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         default:
           $ref: '#/components/responses/UnexpectedError'
 security:
-  - basicAuth: [ ]
+  - basicAuth: []
 components:
   securitySchemes:
     basicAuth:
       type: http
       scheme: basic
   schemas:
-    ListIconParameter:
-      type: object
-      additionalProperties: true
-      properties:
-        Filter:
-          $ref: "#/components/schemas/IconFilter"
-    IconFilter:
-      type: object
-      additionalProperties: true
-      properties:
-        Scope:
-          type: string
-          enum:
-            - user
-            - shared
-        Name:
-          type: array
-          items:
-            type: string
-        Tags.Name:
-          type: array
-          items:
-            type: string
     ID:
       oneOf:
         - type: integer
         - type: string
       format: int64
-    Icon:
-      type: object
-      properties:
-        Availability:
-          type: string
-        CreatedAt:
-          type: string
-        ID:
-          $ref: "#/components/schemas/ID"
-        Index:
-          type: integer
-        ModifiedAt:
-          type: string
-        Name:
-          type: string
-        Scope:
-          type: string
-        Tags:
-          type: array
-          items:
-            type: string
-        URL:
-          type: string
-    Icons:
-      allOf:
-        - $ref: "#/components/schemas/FindResultMeta"
-        - type: object
-          properties:
-            Icons:
-              type: array
-              items:
-                $ref: "#/components/schemas/Icon"
     FindResultMeta:
       type: object
       properties:
@@ -184,6 +129,61 @@ components:
           type: string
         error_msg:
           type: string
+    IconFindParameter:
+      type: object
+      additionalProperties: true
+      properties:
+        Filter:
+          $ref: '#/components/schemas/IconFindFilter'
+    IconFindFilter:
+      type: object
+      additionalProperties: true
+      properties:
+        Scope:
+          type: string
+          enum:
+            - user
+            - shared
+        Name:
+          type: array
+          items:
+            type: string
+        Tags.Name:
+          type: array
+          items:
+            type: string
+    Icon:
+      type: object
+      properties:
+        Availability:
+          type: string
+        CreatedAt:
+          type: string
+        ID:
+          $ref: '#/components/schemas/ID'
+        Index:
+          type: integer
+        ModifiedAt:
+          type: string
+        Name:
+          type: string
+        Scope:
+          type: string
+        Tags:
+          type: array
+          items:
+            type: string
+        URL:
+          type: string
+    Icons:
+      allOf:
+        - $ref: '#/components/schemas/FindResultMeta'
+        - type: object
+          properties:
+            Icons:
+              type: array
+              items:
+                $ref: '#/components/schemas/Icon'
   responses:
     UnauthorizedError:
       description: Authentication information is missing or invalid
@@ -194,10 +194,10 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/APIError"
+            $ref: '#/components/schemas/APIError'
     UnexpectedError:
       description: unexpected error
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/APIError"
+            $ref: '#/components/schemas/APIError'

--- a/definitions/v1.1/openapi.yaml
+++ b/definitions/v1.1/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: "3.0.3"
 tags:
   - name: icons
     description: Operations for Icon resource

--- a/src/v1.1/components/responses/401.yaml
+++ b/src/v1.1/components/responses/401.yaml
@@ -1,0 +1,9 @@
+description: Authentication information is missing or invalid
+headers:
+  WWW_Authenticate:
+    schema:
+      type: string
+content:
+  application/json:
+    schema:
+      $ref: "../schema/common/APIError.yaml"

--- a/src/v1.1/components/responses/default.yaml
+++ b/src/v1.1/components/responses/default.yaml
@@ -1,0 +1,5 @@
+description: unexpected error
+content:
+  application/json:
+    schema:
+      $ref: "../schema/common/APIError.yaml"

--- a/src/v1.1/components/responses/index.yaml
+++ b/src/v1.1/components/responses/index.yaml
@@ -1,0 +1,4 @@
+UnauthorizedError:
+  $ref: "./401.yaml"
+UnexpectedError:
+  $ref: "./default.yaml"

--- a/src/v1.1/components/schema/common/APIError.yaml
+++ b/src/v1.1/components/schema/common/APIError.yaml
@@ -1,0 +1,10 @@
+type: object
+properties:
+  is_fatal:
+    type: boolean
+  serial:
+    type: string
+  error_code:
+    type: string
+  error_msg:
+    type: string

--- a/src/v1.1/components/schema/common/FindResultMeta.yaml
+++ b/src/v1.1/components/schema/common/FindResultMeta.yaml
@@ -1,0 +1,10 @@
+type: object
+properties:
+  Count:
+    type: integer
+  From:
+    type: integer
+  Total:
+    type: integer
+  is_ok:
+    type: boolean

--- a/src/v1.1/components/schema/common/ID.yaml
+++ b/src/v1.1/components/schema/common/ID.yaml
@@ -1,0 +1,4 @@
+oneOf:
+  - type: integer
+  - type: string
+format: int64

--- a/src/v1.1/components/schema/icon/Icon.yaml
+++ b/src/v1.1/components/schema/icon/Icon.yaml
@@ -1,0 +1,22 @@
+type: object
+properties:
+  Availability:
+    type: string
+  CreatedAt:
+    type: string
+  ID:
+    $ref: "../common/ID.yaml"
+  Index:
+    type: integer
+  ModifiedAt:
+    type: string
+  Name:
+    type: string
+  Scope:
+    type: string
+  Tags:
+    type: array
+    items:
+      type: string
+  URL:
+    type: string

--- a/src/v1.1/components/schema/icon/IconFindFilter.yaml
+++ b/src/v1.1/components/schema/icon/IconFindFilter.yaml
@@ -1,0 +1,16 @@
+type: object
+additionalProperties: true
+properties:
+  Scope:
+    type: string
+    enum:
+      - user
+      - shared
+  Name:
+    type: array
+    items:
+      type: string
+  Tags.Name:
+    type: array
+    items:
+      type: string

--- a/src/v1.1/components/schema/icon/IconFindParameter.yaml
+++ b/src/v1.1/components/schema/icon/IconFindParameter.yaml
@@ -1,0 +1,5 @@
+type: object
+additionalProperties: true
+properties:
+  Filter:
+    $ref: "./IconFindFilter.yaml"

--- a/src/v1.1/components/schema/icon/Icons.yaml
+++ b/src/v1.1/components/schema/icon/Icons.yaml
@@ -1,0 +1,8 @@
+allOf:
+  - $ref: "../common/FindResultMeta.yaml"
+  - type: object
+    properties:
+      Icons:
+        type: array
+        items:
+          $ref: "./Icon.yaml"

--- a/src/v1.1/components/schema/index.yaml
+++ b/src/v1.1/components/schema/index.yaml
@@ -1,0 +1,17 @@
+# common
+ID:
+  $ref: './common/ID.yaml'
+FindResultMeta:
+  $ref: './common/FindResultMeta.yaml'
+APIError:
+  $ref: './common/APIError.yaml'
+
+# icon
+IconFindParameter:
+  $ref: './icon/IconFindParameter.yaml'
+IconFindFilter:
+  $ref: './icon/IconFindFilter.yaml'
+Icon:
+  $ref: './icon/Icon.yaml'
+Icons:
+  $ref: './icon/Icons.yaml'

--- a/src/v1.1/paths/icon/actions.yaml
+++ b/src/v1.1/paths/icon/actions.yaml
@@ -1,0 +1,24 @@
+get:
+  summary: Info for a specific Icon
+  description: Info for a specific Icon
+  operationId: showIconById
+  tags:
+    - icons
+  parameters:
+    - name: iconId
+      in: path
+      required: true
+      description: The id of the icon to retrieve
+      schema:
+        $ref: '../../components/schema/common/ID.yaml'
+  responses:
+    '200':
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schema/icon/Icon.yaml'
+    '401':
+      $ref: '../../components/responses/401.yaml'
+    default:
+      $ref: '../../components/responses/default.yaml'

--- a/src/v1.1/paths/icon/create.yaml
+++ b/src/v1.1/paths/icon/create.yaml
@@ -1,0 +1,17 @@
+post:
+  summary: Create a icon
+  description: Create a icon
+  operationId: createIcons
+  tags:
+    - icons
+  responses:
+    '200':
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schema/icon/Icon.yaml'
+    '401':
+      $ref: '../../components/responses/401.yaml'
+    default:
+      $ref: '../../components/responses/default.yaml'

--- a/src/v1.1/paths/icon/find.yaml
+++ b/src/v1.1/paths/icon/find.yaml
@@ -1,0 +1,25 @@
+get:
+  summary: List all Icons
+  description: List all Icons
+  operationId: listIcons
+  tags:
+    - icons
+  parameters:
+    - in: path
+      required: true
+      name: "params"
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schema/icon/IconFindParameter.yaml'
+  responses:
+    '200':
+      description: An array of icons
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schema/icon/Icon.yaml'
+    '401':
+      $ref: '../../components/responses/401.yaml'
+    default:
+      $ref: '../../components/responses/default.yaml'

--- a/src/v1.1/root.yaml
+++ b/src/v1.1/root.yaml
@@ -1,0 +1,44 @@
+openapi: "3.0.3"
+tags:
+  - name: icons
+    description: Operations for Icon resource
+info:
+  title: SAKURA Cloud APIs
+  version: 1.0.0
+  description: This is a definitions for SAKURA Cloud APIs.
+  termsOfService: https://www.sakura.ad.jp/agreement/
+  contact:
+    name: Maintainers
+    url: https://github.com/sacloud/schema
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: https://secure.sakura.ad.jp/cloud/zone/{zone}/api/cloud/1.1
+    variables:
+      zone:
+        default: is1a
+        enum:
+          - is1a
+          - is1b
+          - tk1a
+          - tk1b
+          - tk1v
+paths:
+  /icon?{params}:
+    $ref: './paths/icon/find.yaml'
+  /icon:
+    $ref: './paths/icon/create.yaml'
+  /icon/{iconId}:
+    $ref: './paths/icon/actions.yaml'
+security:
+  - basicAuth: [ ]
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+  schemas:
+    $ref: './components/schema/index.yaml'
+  responses:
+    $ref: './components/responses/index.yaml'


### PR DESCRIPTION
- 定義を以下のように分割する。
```console
.
├── definitions           # src以下の定義から生成される。1ファイルに定義をまとめたもの(JSON or YAML)
│   └── v1.1
│       ├── README.md
│       ├── openapi.json
│       └── openapi.yaml
└── src
    └── v1.1
        ├── components 
        │   ├── responses # レスポンス
        │   └── schema    # スキーマ 
        ├── paths
        │   └── icon      # 各リソースごとのパス
        └── root.yaml     # 定義本体
```

- components/parameterについては今後様子を見ながら分割するか検討する
- `definitions`配下の自動生成は未実装。現状は各作業時に`make gen`して更新する必要がある。
  今後様子を見ながら自動化するか検討する